### PR TITLE
Add NASA-sourced temperature map below location map

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { RiskChart } from "@/components/risk-chart"
 import { DriversTable } from "@/components/drivers-table"
 import { MapPlaceholder } from "@/components/map-placeholder"
 import { ExplanationPanel } from "@/components/explanation-panel"
+import { TemperatureMap } from "@/components/temperature-map"
 import { Footer } from "@/components/footer"
 import { Cloud } from "lucide-react"
 import type { ApiResponse, QueryParams } from "@/types"
@@ -200,11 +201,19 @@ export default function Home() {
                 <RiskChart risks={results.risks} />
                 <div className="grid lg:grid-cols-2 gap-6">
                   <DriversTable drivers={results.drivers} />
-                  <MapPlaceholder
-                    lat={results.meta.lat}
-                    lon={results.meta.lon}
-                    locationName={results.meta.locationName}
-                  />
+                  <div className="space-y-6">
+                    <MapPlaceholder
+                      lat={results.meta.lat}
+                      lon={results.meta.lon}
+                      locationName={results.meta.locationName}
+                    />
+                    <TemperatureMap
+                      lat={results.meta.lat}
+                      lon={results.meta.lon}
+                      locationName={results.meta.locationName}
+                      date={results.meta.startDate}
+                    />
+                  </div>
                 </div>
                 <ExplanationPanel explanation={results.explanation} disclaimer={results.disclaimer} />
               </>

--- a/components/temperature-map.tsx
+++ b/components/temperature-map.tsx
@@ -1,0 +1,65 @@
+import { Card } from "@/components/ui/card"
+
+interface TemperatureMapProps {
+  lat: number
+  lon: number
+  locationName: string
+  date?: string
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max)
+
+export function TemperatureMap({ lat, lon, locationName, date }: TemperatureMapProps) {
+  const regionPadding = 5
+  const minLat = clamp(lat - regionPadding, -90, 90)
+  const maxLat = clamp(lat + regionPadding, -90, 90)
+  const minLon = clamp(lon - regionPadding, -180, 180)
+  const maxLon = clamp(lon + regionPadding, -180, 180)
+
+  const targetDate = date || new Date().toISOString().split("T")[0]
+
+  const params = new URLSearchParams({
+    service: "WMS",
+    request: "GetMap",
+    version: "1.3.0",
+    layers: "MODIS_Terra_Land_Surface_Temp_Day",
+    styles: "",
+    format: "image/png",
+    width: "512",
+    height: "512",
+    crs: "EPSG:4326",
+    bbox: `${minLat},${minLon},${maxLat},${maxLon}`,
+    time: targetDate,
+  })
+
+  const mapUrl = `https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi?${params.toString()}`
+
+  const title = locationName
+    ? `NASA surface temperature map for ${locationName}`
+    : "NASA surface temperature map"
+
+  return (
+    <Card className="h-full bg-card border-border p-6 flex flex-col gap-4">
+      <div>
+        <h3 className="text-lg font-semibold text-foreground">Surface Temperature Map</h3>
+        <p className="text-sm text-muted-foreground">
+          Daily land surface temperature from NASA MODIS (Terra) within ~
+          <span className="font-mono">{regionPadding}°</span> of the selected location.
+        </p>
+      </div>
+      <div className="relative flex-1 min-h-[320px] rounded-lg bg-card overflow-hidden border border-border">
+        <img src={mapUrl} alt={title} className="absolute inset-0 h-full w-full object-cover" />
+        <div className="absolute bottom-4 left-4 bg-card/95 backdrop-blur rounded-md px-3 py-2 shadow-sm border border-border text-sm text-foreground">
+          <p className="font-medium">{locationName}</p>
+          <p className="text-xs text-muted-foreground font-mono">
+            {lat.toFixed(4)}°, {lon.toFixed(4)}°
+          </p>
+          <p className="text-xs text-muted-foreground">{targetDate}</p>
+        </div>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Source: <a href="https://earthdata.nasa.gov/eosdis/science-system-description/eosdis-components/gibs" target="_blank" rel="noreferrer" className="underline hover:text-foreground">NASA Global Imagery Browse Services (GIBS)</a>
+      </p>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary
- add a TemperatureMap component that requests NASA MODIS land surface temperature imagery via GIBS
- render the NASA temperature map card beneath the existing location map in the assessment results layout

## Testing
- pnpm lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e3211217f88328b08242e469c630c5