### PR TITLE
Replace temperature map overlay with NASA data

### DIFF
--- a/components/temperature-map.tsx
+++ b/components/temperature-map.tsx
@@ -46,20 +46,26 @@ export function TemperatureMap({ drivers, tempUnit, lat, lon, locationName }: Te
       const mapElement = document.getElementById("temperature-map")
       if (!mapElement) return
 
-      map = L.map(mapElement).setView([lat, lon], 6)
+      map = L.map(mapElement, {
+        maxZoom: 8,
+        minZoom: 1,
+      }).setView([lat, lon], 6)
 
       L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
         attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
         opacity: 0.7,
       }).addTo(map)
 
-      // This provides actual real-time temperature data from weather stations
+      // NASA GIBS land surface temperature layer (Celsius)
       L.tileLayer(
-        "https://tile.openweathermap.org/map/temp_new/{z}/{x}/{y}.png?appid=8d3f4ca3ba012c87309e0b8ecb37be1b",
+        "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_Land_Surface_Temp_Day_C/GoogleMapsCompatible_Level8/{z}/{y}/{x}.png",
         {
-          attribution: 'Temperature data &copy; <a href="https://openweathermap.org">OpenWeatherMap</a>',
+          attribution:
+            'Temperature imagery courtesy of NASA EOSDIS LANCE and GIBS/Worldview',
           opacity: 0.6,
-          maxZoom: 19,
+          tileSize: 256,
+          maxZoom: 8,
+          minZoom: 1,
         },
       ).addTo(map)
 
@@ -125,7 +131,7 @@ export function TemperatureMap({ drivers, tempUnit, lat, lon, locationName }: Te
           {/* Legend overlay */}
           <div className="absolute bottom-4 right-4 bg-card/95 backdrop-blur-sm rounded-lg px-4 py-3 shadow-lg border border-border z-[1000]">
             <p className="text-xs font-semibold mb-2 text-foreground">Temperature Overlay</p>
-            <p className="text-[10px] text-muted-foreground mb-2">Real-time data from weather stations</p>
+            <p className="text-[10px] text-muted-foreground mb-2">NASA GIBS Land Surface Temperature (°C)</p>
             <div className="flex gap-1">
               <div className="flex flex-col items-center">
                 <div className="w-6 h-6 rounded" style={{ background: "#9d5cff" }} />


### PR DESCRIPTION
## Summary
- replace the OpenWeatherMap temperature tile overlay with NASA GIBS land surface temperature imagery
- adjust map zoom limits and legend copy to align with the new data source

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3272fbe8c8328b019696d1dfa1d01