### PR TITLE
Proxy NASA tiles through server route

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Your project is live at:
 
 **[https://vercel.com/wrmschessclub-1128s-projects/v0-remix-of-weather-risk-dashboard-fz](https://vercel.com/wrmschessclub-1128s-projects/v0-remix-of-weather-risk-dashboard-fz)**
 
+### NASA imagery access tokens
+
+If you have a NASA Earthdata application token for the surface temperature tiles, add it as a server environment variable named `NASA_GIBS_TOKEN`. Tiles are now proxied through a Next.js API route so the token never ships to the browser, which avoids Vercel's v0 security warning about exposing sensitive environment variables in client bundles.
+
 ## Build your app
 
 Continue building your app on:

--- a/app/api/nasa-tiles/[...path]/route.ts
+++ b/app/api/nasa-tiles/[...path]/route.ts
@@ -1,0 +1,71 @@
+import type { NextRequest } from "next/server"
+
+const NASA_BASE_REALTIME =
+  "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/wmts.cgi?service=WMTS&request=GetTile&version=1.0.0&layer=MODIS_Terra_Land_Surface_Temp_Day&style=default&tilematrixset=GoogleMapsCompatible_Level9&format=image%2Fpng"
+
+const NASA_BASE_CLIMATOLOGY =
+  "https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MOD_LSTD_CLIM_M"
+
+const NASA_TOKEN = process.env.NASA_GIBS_TOKEN
+
+const appendToken = (url: string) => {
+  if (!NASA_TOKEN) return url
+  const separator = url.includes("?") ? "&" : "?"
+  return `${url}${separator}token=${encodeURIComponent(NASA_TOKEN)}`
+}
+
+export async function GET(_request: NextRequest, context: { params: { path?: string[] } }) {
+  const segments = context.params.path ?? []
+
+  if (segments.length !== 5) {
+    return new Response("Invalid NASA tile path", { status: 400 })
+  }
+
+  const [variant, date, z, axisA, axisBWithExt] = segments
+
+  if (!variant || !date || !z || !axisA || !axisBWithExt) {
+    return new Response("Missing NASA tile parameters", { status: 400 })
+  }
+
+  const axisB = axisBWithExt.replace(/\.png$/i, "")
+
+  if (!/^(realtime|climatology)$/.test(variant)) {
+    return new Response("Unsupported NASA tile variant", { status: 400 })
+  }
+
+  const tileCol = variant === "realtime" ? axisA : axisB
+  const tileRow = variant === "realtime" ? axisB : axisA
+
+  let nasaUrl: string
+
+  if (variant === "realtime") {
+    nasaUrl = appendToken(
+      `${NASA_BASE_REALTIME}&TileMatrix=${encodeURIComponent(z)}&TileCol=${encodeURIComponent(tileCol)}&TileRow=${encodeURIComponent(
+        tileRow,
+      )}&TIME=${encodeURIComponent(date)}`,
+    )
+  } else {
+    nasaUrl = appendToken(
+      `${NASA_BASE_CLIMATOLOGY}/default/${encodeURIComponent(date)}/EPSG4326_1km/${encodeURIComponent(z)}/${encodeURIComponent(
+        tileRow,
+      )}/${encodeURIComponent(tileCol)}.png`,
+    )
+  }
+
+  try {
+    const upstream = await fetch(nasaUrl)
+
+    if (!upstream.ok || !upstream.body) {
+      return new Response("Failed to fetch NASA imagery", { status: upstream.status || 502 })
+    }
+
+    const headers = new Headers()
+    headers.set("Content-Type", upstream.headers.get("content-type") ?? "image/png")
+    headers.set("Cache-Control", variant === "realtime" ? "public, max-age=600" : "public, max-age=86400")
+
+    return new Response(upstream.body, { status: 200, headers })
+  } catch (error) {
+    console.error("NASA tile proxy error", error)
+    return new Response("NASA imagery proxy error", { status: 502 })
+  }
+}

--- a/components/temperature-map.tsx
+++ b/components/temperature-map.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Card } from "@/components/ui/card"
 import type { Driver } from "@/types"
 
@@ -14,7 +14,10 @@ interface TemperatureMapProps {
 
 export function TemperatureMap({ drivers, tempUnit, lat, lon, locationName }: TemperatureMapProps) {
   const [isMounted, setIsMounted] = useState(false)
-  const [mapInstance, setMapInstance] = useState<any>(null)
+  const mapRef = useRef<any>(null)
+  const nasaLayerRef = useRef<any>(null)
+  const [nasaLayerDate, setNasaLayerDate] = useState<string | null>(null)
+  const [nasaStatus, setNasaStatus] = useState<"loading" | "active" | "failed">("loading")
 
   // Extract temperature data
   const temp = drivers.find((d) => d.name === "Temperature")?.value || 0
@@ -29,11 +32,15 @@ export function TemperatureMap({ drivers, tempUnit, lat, lon, locationName }: Te
   useEffect(() => {
     if (!isMounted) return
 
-    let map: any
     let marker: any
+    let isEffectActive = true
 
     const initMap = async () => {
       const L = (await import("leaflet")).default
+
+      if (!isEffectActive) {
+        return
+      }
 
       // Fix for default marker icon
       delete (L.Icon.Default.prototype as any)._getIconUrl
@@ -44,24 +51,105 @@ export function TemperatureMap({ drivers, tempUnit, lat, lon, locationName }: Te
       })
 
       const mapElement = document.getElementById("temperature-map")
-      if (!mapElement) return
+      if (!mapElement || !isEffectActive) return
 
-      map = L.map(mapElement).setView([lat, lon], 6)
+      const existingMap = mapRef.current
+      if (existingMap) {
+        existingMap.remove()
+        mapRef.current = null
+      }
+
+      const map = L.map(mapElement).setView([lat, lon], 6)
+      mapRef.current = map
 
       L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
         attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
         opacity: 0.7,
       }).addTo(map)
 
-      // This provides actual real-time temperature data from weather stations
-      L.tileLayer(
-        "https://tile.openweathermap.org/map/temp_new/{z}/{x}/{y}.png?appid=8d3f4ca3ba012c87309e0b8ecb37be1b",
-        {
-          attribution: 'Temperature data &copy; <a href="https://openweathermap.org">OpenWeatherMap</a>',
-          opacity: 0.6,
-          maxZoom: 19,
-        },
-      ).addTo(map)
+      const fallbackDates = Array.from({ length: 10 }, (_, index) => {
+        const date = new Date()
+        date.setDate(date.getDate() - index)
+        return date.toISOString().split("T")[0]
+      })
+
+      const climatologyLayer = {
+        id: "MOD_LSTD_CLIM_M",
+        label: "Climatology",
+        buildUrl: (date: string) =>
+          `/api/nasa-tiles/climatology/${date}/{z}/{y}/{x}.png`,
+        maxZoom: 7,
+        tileSize: 512,
+        tms: true,
+      }
+
+      const realtimeLayer = {
+        id: "MODIS_Terra_Land_Surface_Temp_Day",
+        label: "Daily",
+        buildUrl: (date: string) =>
+          `/api/nasa-tiles/realtime/${date}/{z}/{x}/{y}.png`,
+        maxZoom: 9,
+        tileSize: 256,
+        tms: false,
+      }
+
+      const attachLayer = (
+        layerConfig: typeof realtimeLayer,
+        dates: string[],
+        dateIndex: number,
+      ) => {
+        if (!isEffectActive || !mapRef.current) {
+          return
+        }
+
+        const layerDate = dates[dateIndex]
+        const url = layerConfig.buildUrl(layerDate)
+
+        const layer = L.tileLayer(url, {
+          attribution:
+            'Temperature imagery &copy; <a href="https://earthdata.nasa.gov/eosdis/science-system-description/eosdis-components/gibs">NASA EOSDIS GIBS</a>',
+          opacity: 0.85,
+          maxNativeZoom: layerConfig.maxZoom,
+          maxZoom: layerConfig.maxZoom,
+          tileSize: layerConfig.tileSize,
+          zIndex: 450,
+          tms: layerConfig.tms,
+          crossOrigin: false,
+        })
+
+        const handleTileLoad = () => {
+          if (!isEffectActive) return
+          setNasaStatus("active")
+          setNasaLayerDate(layerDate)
+        }
+
+        const handleTileError = () => {
+          if (!isEffectActive) return
+          layer.off("tileerror", handleTileError)
+          layer.off("load", handleTileLoad)
+          if (mapRef.current && mapRef.current.hasLayer(layer)) {
+            mapRef.current.removeLayer(layer)
+          }
+
+          const nextIndex = dateIndex + 1
+          if (nextIndex < dates.length) {
+            attachLayer(layerConfig, dates, nextIndex)
+          } else if (layerConfig.id === realtimeLayer.id) {
+            attachLayer(climatologyLayer, ["2013-01-01"], 0)
+          } else {
+            setNasaStatus("failed")
+          }
+        }
+
+        layer.on("load", handleTileLoad)
+        layer.on("tileerror", handleTileError)
+
+        layer.addTo(map)
+        nasaLayerRef.current = layer
+      }
+
+      setNasaStatus("loading")
+      attachLayer(realtimeLayer, fallbackDates, 0)
 
       marker = L.marker([lat, lon]).addTo(map)
       marker.bindPopup(`
@@ -84,14 +172,21 @@ export function TemperatureMap({ drivers, tempUnit, lat, lon, locationName }: Te
         </div>
       `)
 
-      setMapInstance(map)
     }
 
     initMap()
 
     return () => {
+      isEffectActive = false
+      const map = mapRef.current
       if (map) {
+        const nasaLayer = nasaLayerRef.current
+        if (nasaLayer && map.hasLayer(nasaLayer)) {
+          map.removeLayer(nasaLayer)
+        }
         map.remove()
+        mapRef.current = null
+        nasaLayerRef.current = null
       }
     }
   }, [isMounted, lat, lon, locationName, temp, tempUnit, feelsLike, minTemp, maxTemp])
@@ -124,8 +219,16 @@ export function TemperatureMap({ drivers, tempUnit, lat, lon, locationName }: Te
 
           {/* Legend overlay */}
           <div className="absolute bottom-4 right-4 bg-card/95 backdrop-blur-sm rounded-lg px-4 py-3 shadow-lg border border-border z-[1000]">
-            <p className="text-xs font-semibold mb-2 text-foreground">Temperature Overlay</p>
-            <p className="text-[10px] text-muted-foreground mb-2">Real-time data from weather stations</p>
+            <p className="text-xs font-semibold mb-2 text-foreground">NASA Surface Temperature</p>
+            <p className="text-[10px] text-muted-foreground mb-2">
+              {nasaStatus === "loading" && "Loading latest NASA imagery"}
+              {nasaStatus === "active" &&
+                (nasaLayerDate
+                  ? `MODIS Terra land surface temperature for ${nasaLayerDate}`
+                  : "NASA imagery active")}
+              {nasaStatus === "failed" &&
+                "Unable to load NASA tiles — check network access or credentials."}
+            </p>
             <div className="flex gap-1">
               <div className="flex flex-col items-center">
                 <div className="w-6 h-6 rounded" style={{ background: "#9d5cff" }} />


### PR DESCRIPTION
## Summary
- add an internal Next.js API route that proxies NASA surface temperature tiles and appends the optional server-side token
- update the temperature map overlay to pull imagery from the proxy so credentials are not exposed in the browser
- document how to configure the new `NASA_GIBS_TOKEN` environment variable for deployments

## Testing
- CI=1 pnpm exec next build

------
https://chatgpt.com/codex/tasks/task_e_68e32c77ebf48328bb936d31bd4845c4