### PR TITLE
Add NASA Worldview snapshot to results view

### DIFF
--- a/app/components/NasaSnapshotMap.tsx
+++ b/app/components/NasaSnapshotMap.tsx
@@ -1,0 +1,73 @@
+import * as React from "react"
+
+function clamp(v: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, v))
+}
+
+export default function NasaSnapshotMap({
+  lat,
+  lon,
+  dateISO,
+  width = 1280,
+  height = 720,
+  kmHalfSize = 150,
+}: {
+  lat: number
+  lon: number
+  dateISO: string
+  width?: number
+  height?: number
+  kmHalfSize?: number
+}) {
+  const dateStr = dateISO.slice(0, 10)
+
+  const dLat = kmHalfSize / 111
+  const dLon = kmHalfSize / (111 * Math.cos((lat * Math.PI) / 180) || 1e-6)
+
+  const south = clamp(lat - dLat, -90, 90)
+  const north = clamp(lat + dLat, -90, 90)
+  const west = clamp(lon - dLon, -180, 180)
+  const east = clamp(lon + dLon, -180, 180)
+
+  const src = [
+    "https://wvs.earthdata.nasa.gov/api/v1/snapshot?REQUEST=GetSnapshot",
+    "LAYERS=MODIS_Terra_CorrectedReflectance_TrueColor,Reference_Features,Reference_Labels",
+    "CRS=EPSG:4326",
+    `BBOX=${west},${south},${east},${north}`,
+    `TIME=${dateStr}`,
+    "FORMAT=image/png",
+    `WIDTH=${width}`,
+    `HEIGHT=${height}`,
+  ].join("&")
+
+  const [loaded, setLoaded] = React.useState(false)
+  const [errored, setErrored] = React.useState(false)
+
+  if (!Number.isFinite(lat) || !Number.isFinite(lon) || !dateStr) {
+    return null
+  }
+
+  return (
+    <div className="w-full">
+      {!loaded && !errored && (
+        <div className="w-full h-64 animate-pulse rounded-xl bg-gray-300" aria-hidden />
+      )}
+      {!errored && (
+        <a href={src} target="_blank" rel="noopener noreferrer">
+          <img
+            src={src}
+            alt={`Satellite snapshot (True Color) for ${dateStr} around ${lat.toFixed(3)},${lon.toFixed(3)}`}
+            className={`w-full rounded-xl ${loaded ? "" : "hidden"}`}
+            onLoad={() => setLoaded(true)}
+            onError={() => setErrored(true)}
+          />
+        </a>
+      )}
+      {errored && (
+        <p className="text-sm text-gray-600">
+          NASA snapshot unavailable right now. Try another date or zoom level.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,8 @@ import { ExplanationPanel } from "@/components/explanation-panel"
 import { Footer } from "@/components/footer"
 import { Cloud } from "lucide-react"
 import { TemperatureMap } from "@/components/temperature-map"
+import NasaSnapshotMap from "@/app/components/NasaSnapshotMap"
+import { Card } from "@/components/ui/card"
 import type { ApiResponse, QueryParams } from "@/types"
 
 export default function Home() {
@@ -131,11 +133,21 @@ export default function Home() {
                 <RiskChart risks={results.risks} />
                 <div className="grid lg:grid-cols-2 gap-6">
                   <DriversTable drivers={results.drivers} />
-                  <MapPlaceholder
-                    lat={results.meta.lat}
-                    lon={results.meta.lon}
-                    locationName={results.meta.locationName}
-                  />
+                  <div className="space-y-6">
+                    <MapPlaceholder
+                      lat={results.meta.lat}
+                      lon={results.meta.lon}
+                      locationName={results.meta.locationName}
+                    />
+                    <Card className="bg-card border-border p-6">
+                      <h3 className="text-lg font-semibold text-foreground mb-4">NASA Satellite Snapshot</h3>
+                      <NasaSnapshotMap
+                        lat={results.meta.lat}
+                        lon={results.meta.lon}
+                        dateISO={results.meta.startDate}
+                      />
+                    </Card>
+                  </div>
                 </div>
                 <TemperatureMap
                   drivers={results.drivers}


### PR DESCRIPTION
## Summary
- add a reusable `NasaSnapshotMap` component that renders NASA Worldview Snapshots imagery around the selected coordinates
- surface the satellite snapshot in the results view alongside the map and drivers data, opening the full image on click

## Testing
- pnpm lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e34d9a5790832888465282203f9287